### PR TITLE
liquid ~> 2.6.1

### DIFF
--- a/landable.gemspec
+++ b/landable.gemspec
@@ -31,7 +31,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'rack-cors', '>= 0.2.7'
   gem.add_dependency 'active_model_serializers', '~> 0.8'
   gem.add_dependency 'carrierwave'
-  gem.add_dependency 'liquid'
+  gem.add_dependency 'liquid',    '~> 2.6.1'
   gem.add_dependency 'fog'
   gem.add_dependency 'rest-client'
   gem.add_dependency 'builder'


### PR DESCRIPTION
`landable.gemspec` should specify a version of `liquid`.

Liquid 3.0.0 pretty much fails all the specs:

```
  31) Landable::Api::PagesController#index renders pages as json
     Failure/Error: let(:pages) { @pages ||= create_list(:page, 5) }
     ActiveRecord::RecordInvalid:
       Validation failed: Body had a problem: private method `new' called for Landable::Liquid::TitleTag:Class
     # ./spec/controllers/landable/api/pages_controller_spec.rb:56:in `block (3 levels) in <module:Api>'
     # ./spec/controllers/landable/api/pages_controller_spec.rb:57:in `block (3 levels) in <module:Api>'
```
