### PR TITLE
Force Template Slug to not have a space

### DIFF
--- a/app/models/landable/template.rb
+++ b/app/models/landable/template.rb
@@ -10,6 +10,8 @@ module Landable
     validates_uniqueness_of :name, case_sensitive: false
     validates_uniqueness_of :slug, case_sensitive: false
 
+    before_save :slug_has_no_spaces
+
 
     belongs_to :published_revision,   class_name: 'Landable::TemplateRevision'
     has_many   :audits,               class_name: 'Landable::Audit', as: :auditable
@@ -61,6 +63,12 @@ module Landable
       self.slug          = revision.slug
 
       save!
+    end
+
+    def slug_has_no_spaces
+      if self.slug =~ /\s/ # check if whitespace
+        self.slug = self.slug.underscore.gsub(/[^\w_]/, '_').gsub(/_{2,}/, '_')
+      end
     end
 
     class << self

--- a/spec/concerns/landable/has_templates_spec.rb
+++ b/spec/concerns/landable/has_templates_spec.rb
@@ -3,7 +3,10 @@ require 'spec_helper'
 module Landable
   describe HasTemplates do
 
-    before(:each) { create_list :template, 3 }
+    before(:each) do 
+      create_list :template, 2
+      create :template, slug: 'I have a space'
+    end
 
     let(:templates) { Landable::Template.last(3) }
     let(:subject) {

--- a/spec/models/landable/template_spec.rb
+++ b/spec/models/landable/template_spec.rb
@@ -119,5 +119,24 @@ module Landable
         template.revert_to! revision
       end
     end
+
+    describe '#slug_has_no_spaces' do
+      it 'should not allow a slug with out underscores' do
+        t = build :template, slug: 'I have no space'
+        t.name = 'No Space'
+        t.save!
+
+        t.slug.should_not == 'I have no space'
+        t.slug.should == 'i_have_no_space'
+      end
+
+      it 'should allow the name to set the slug' do
+        t = build :template, slug: nil
+        t.name = 'I have no space'
+        t.save!
+
+        t.slug.should == 'i_have_no_space'
+      end
+    end
   end
 end


### PR DESCRIPTION
When templates have spaces in their slugs, they break when publishing.  Break how `has_templates.rb` works, it will not be able to identity the correct template that exist in the pages body (code) and thus the template will not show up on the page

paired with @ryancowan  
