### PR TITLE
Deleted templates still firing

### DIFF
--- a/app/models/concerns/landable/has_templates.rb
+++ b/app/models/concerns/landable/has_templates.rb
@@ -19,7 +19,7 @@ module Landable
       end
 
       def templates
-        Landable::Template.where(slug: template_names, deleted_at: nil)
+        Landable::Template.where(slug: template_names)
       end
 
       # passthrough for body=; clears the template_names cache in the process

--- a/app/models/concerns/landable/has_templates.rb
+++ b/app/models/concerns/landable/has_templates.rb
@@ -19,7 +19,7 @@ module Landable
       end
 
       def templates
-        Landable::Template.where(slug: template_names)
+        Landable::Template.where(slug: template_names, deleted_at: nil)
       end
 
       # passthrough for body=; clears the template_names cache in the process

--- a/lib/landable/liquid/tags.rb
+++ b/lib/landable/liquid/tags.rb
@@ -73,28 +73,28 @@ module Landable
       def render(context)
         template = Landable::Template.find_by_slug @template_slug
 
+        # Handle Templates that are deleted (don't render anything)
+        if template && !template.deleted_at.nil?
         # Handle Templates that are Partials
-        if template.deleted_at.nil?
-          if template && template.partial?
-            responder = context.registers[:responder]
-            # the controller we need for rendering. the request we need to dodge a bug in rails 4.1
-            # (fixed in https://github.com/rails/rails/commit/f6d9b689977c1dca1ed7f149f704d1b4344cd691).
-            # if we need to render pages offline (i.e. without a request) we'll need to rethink this.
-            if responder.try(:controller).try(:request).present?
-              responder.controller.render_to_string(partial: template.file)
-            else
-              "<!-- render error: unable to render \"#{@template_slug}\", no controller/responder present -->"
-            end
-
-          # Handle Published Templates
-          elsif template && template.revisions.where(is_published: true).present?
-            template = template.revisions.where(is_published: true).first
-            ::Liquid::Template.parse(template.body).render @variables
-
-          # Handle Template Errors
+        elsif template && template.partial?
+          responder = context.registers[:responder]
+          # the controller we need for rendering. the request we need to dodge a bug in rails 4.1
+          # (fixed in https://github.com/rails/rails/commit/f6d9b689977c1dca1ed7f149f704d1b4344cd691).
+          # if we need to render pages offline (i.e. without a request) we'll need to rethink this.
+          if responder.try(:controller).try(:request).present?
+            responder.controller.render_to_string(partial: template.file)
           else
-            "<!-- render error: missing published template \"#{@template_slug}\" -->"
+            "<!-- render error: unable to render \"#{@template_slug}\", no controller/responder present -->"
           end
+
+        # Handle Published Templates
+        elsif template && template.revisions.where(is_published: true).present?
+          template = template.revisions.where(is_published: true).first
+          ::Liquid::Template.parse(template.body).render @variables
+
+        # Handle Template Errors
+        else
+          "<!-- render error: missing published template \"#{@template_slug}\" -->"
         end
       end
     end

--- a/lib/landable/liquid/tags.rb
+++ b/lib/landable/liquid/tags.rb
@@ -74,9 +74,10 @@ module Landable
         template = Landable::Template.find_by_slug @template_slug
 
         # Handle Templates that are deleted (don't render anything)
-        if template && !template.deleted_at.nil?
+        return if template && template.deleted_at?
+
         # Handle Templates that are Partials
-        elsif template && template.partial?
+        if template && template.partial?
           responder = context.registers[:responder]
           # the controller we need for rendering. the request we need to dodge a bug in rails 4.1
           # (fixed in https://github.com/rails/rails/commit/f6d9b689977c1dca1ed7f149f704d1b4344cd691).

--- a/lib/landable/liquid/tags.rb
+++ b/lib/landable/liquid/tags.rb
@@ -74,25 +74,27 @@ module Landable
         template = Landable::Template.find_by_slug @template_slug
 
         # Handle Templates that are Partials
-        if template && template.partial?
-          responder = context.registers[:responder]
-          # the controller we need for rendering. the request we need to dodge a bug in rails 4.1
-          # (fixed in https://github.com/rails/rails/commit/f6d9b689977c1dca1ed7f149f704d1b4344cd691).
-          # if we need to render pages offline (i.e. without a request) we'll need to rethink this.
-          if responder.try(:controller).try(:request).present?
-            responder.controller.render_to_string(partial: template.file)
+        if template.deleted_at.nil?
+          if template && template.partial?
+            responder = context.registers[:responder]
+            # the controller we need for rendering. the request we need to dodge a bug in rails 4.1
+            # (fixed in https://github.com/rails/rails/commit/f6d9b689977c1dca1ed7f149f704d1b4344cd691).
+            # if we need to render pages offline (i.e. without a request) we'll need to rethink this.
+            if responder.try(:controller).try(:request).present?
+              responder.controller.render_to_string(partial: template.file)
+            else
+              "<!-- render error: unable to render \"#{@template_slug}\", no controller/responder present -->"
+            end
+
+          # Handle Published Templates
+          elsif template && template.revisions.where(is_published: true).present?
+            template = template.revisions.where(is_published: true).first
+            ::Liquid::Template.parse(template.body).render @variables
+
+          # Handle Template Errors
           else
-            "<!-- render error: unable to render \"#{@template_slug}\", no controller/responder present -->"
+            "<!-- render error: missing published template \"#{@template_slug}\" -->"
           end
-
-        # Handle Published Templates
-        elsif template && template.revisions.where(is_published: true).present?
-          template = template.revisions.where(is_published: true).first
-          ::Liquid::Template.parse(template.body).render @variables
-
-        # Handle Template Errors
-        else
-          "<!-- render error: missing published template \"#{@template_slug}\" -->"
         end
       end
     end


### PR DESCRIPTION
Wrapped the template tag rendering functionality in a deleted_at.nil? check. This change affects the inline "preview" tab and the "view live" button.