### PR TITLE
Create tracker object helper methods

### DIFF
--- a/app/helpers/landable/traffic_helper.rb
+++ b/app/helpers/landable/traffic_helper.rb
@@ -1,0 +1,31 @@
+module Landable
+  module TrafficHelper
+    def crawl_tracker
+      @tracker if @tracker.is_a? Landable::Traffic::CrawlTracker
+    end
+
+    def noop_tracker
+      @tracker if @tracker.is_a? Landable::Traffic::NoopTracker
+    end
+
+    def ping_tracker
+      @tracker if @tracker.is_a? Landable::Traffic::PingTracker
+    end
+
+    def scan_tracker
+      @tracker if @tracker.is_a? Landable::Traffic::ScanTracker
+    end
+
+    def scrape_tracker
+      @tracker if @tracker.is_a? Landable::Traffic::ScrapeTracker
+    end
+
+    def user_tracker
+      @tracker if @tracker.is_a? Landable::Traffic::UserTracker
+    end
+
+    def tracker
+      @tracker
+    end
+  end
+end


### PR DESCRIPTION
In order to avoid having to reference the instance variable `@tracker` directly in app code, the following proposes adding a helper and methods to access the tracker instances.