### PR TITLE
Fix user agent type missing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 See README.md before updating this file.
 
 ## Unreleased [#](https://github.com/enova/landable/compare/v1.12.1...master)
+* BugFix: fix LookupBy::Error: "ping" is not in the Landable::Traffic::UserAgentType lookup cache [#52]
 
 ## 1.12.3 [#](https://github.com/enova/landable/compare/v1.12.2...v1.12.3)
 * Feature: Add Traffic Object Helper [#50]

--- a/README.md
+++ b/README.md
@@ -45,6 +45,12 @@ Read more about [Visit Tracking](https://github.com/enova/landable/wiki/Visit-Tr
 
 ## Development
 
+Create a `dummy` user so that the database creation script below will work
+
+```
+psql -c "CREATE USER dummy WITH superuser" -U postgres
+```
+
 Run `./script/redb` to refresh the dummy app's database.
 
 Run the test suite with `rake landable`.

--- a/app/models/landable/traffic/user_agent_type.rb
+++ b/app/models/landable/traffic/user_agent_type.rb
@@ -3,7 +3,7 @@ module Landable
     class UserAgentType < ActiveRecord::Base
       include Landable::TableName
 
-      lookup_by :user_agent_type, cache: true
+      lookup_by :user_agent_type, cache: 5, find_or_create: true
 
       has_many :user_agents
     end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -46,6 +46,4 @@ Dummy::Application.configure do
 
   # Disable the pipeline itself, as in production
   config.assets.compile = false
-
-  config.active_record.raise_in_transactional_callbacks = true
 end

--- a/spec/dummy/config/environments/test.rb
+++ b/spec/dummy/config/environments/test.rb
@@ -13,7 +13,14 @@ Dummy::Application.configure do
   config.eager_load = false
 
   # Configure static asset server for tests with Cache-Control for performance.
-  config.serve_static_assets  = true
+  # deal with Rails 4.2 deprecation of ..._assets
+  if config.respond_to?("serve_static_files")
+    config.serve_static_files = true
+  else
+    config.serve_static_assets  = true
+  end
+
+
   config.static_cache_control = "public, max-age=3600"
 
   # Show full error reports and disable caching.
@@ -39,4 +46,6 @@ Dummy::Application.configure do
 
   # Disable the pipeline itself, as in production
   config.assets.compile = false
+
+  config.active_record.raise_in_transactional_callbacks = true
 end

--- a/spec/lib/landable/tracking_spec.rb
+++ b/spec/lib/landable/tracking_spec.rb
@@ -47,6 +47,32 @@ module Landable
 
         Landable::Traffic::Tracker.for(controller).should be_a(Landable::Traffic::UserTracker)
       end
+
+      it 'should classify user agent NewRelic as ping' do
+        user_agent = "NewRelicPinger/1.0 (1234)"
+        request = double('request', { query_parameters: {}, user_agent: user_agent, format: format })
+        controller = double('controller', { request: request })
+
+        Landable::Traffic::Tracker.for(controller).should be_a(Landable::Traffic::PingTracker)
+      end
+
+      it 'should classify user agent tinfoilsecurity.com as scan' do
+        user_agent = "Mozilla/5.0 (Macintosh; U; Intel Mac OS X 10_6_6; en-us) AppleWebKit/533.19.4"\
+          " (KHTML, like Gecko) Version/5.0.3 Safari/5 Powered by Spider-Pig by tinfoilsecurity.com"
+        request = double('request', { query_parameters: {}, user_agent: user_agent, format: format })
+        controller = double('controller', { request: request })
+
+        Landable::Traffic::Tracker.for(controller).should be_a(Landable::Traffic::ScanTracker)
+      end
+
+      it 'should classify user agent tinfoilsecurity.com as scan' do
+        user_agent = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+        request = double('request', { query_parameters: {}, user_agent: user_agent, format: format })
+        controller = double('controller', { request: request })
+
+        Landable::Traffic::Tracker.for(controller).should be_a(Landable::Traffic::CrawlTracker)
+      end
+
     end
 
     context 'referer' do


### PR DESCRIPTION
This fixes the following error, when "ping" is not in the user_agent_types table... or any of the other three values. It may make more sense for these to be in the seed data, but whatever. Also created tests for setting the UserAgentType to exercise all three different types.

LookupBy::Error: "ping" is not in the <Landable::Traffic::UserAgentType> lookup cache
