### PR TITLE
Default referer path to empty string

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 See README.md before updating this file.
 
 ## Unreleased [#](https://github.com/enova/landable/compare/v1.12.1...master)
+* BugFix: Default referer.path to '' [#60]
 
 ## 1.12.3 [#](https://github.com/enova/landable/compare/v1.12.2...v1.12.3)
 * Feature: Add Traffic Object Helper [#50]

--- a/lib/landable/traffic/tracker.rb
+++ b/lib/landable/traffic/tracker.rb
@@ -237,7 +237,7 @@ module Landable
       end
 
       def referer_uri_path
-        referer_uri.path || ''
+        referer_uri.try(:path) || ''
       end
 
       def external_referer?

--- a/lib/landable/traffic/tracker.rb
+++ b/lib/landable/traffic/tracker.rb
@@ -173,7 +173,7 @@ module Landable
         query       = params.except(*ATTRIBUTION_KEYS)
 
         @referer = Referer.where(domain_id:       Domain[referer_uri.host],
-                                 path_id:         Path[referer_uri.path],
+                                 path_id:         Path[referer_uri_path],
                                  query_string_id: QueryString[query.to_query],
                                  attribution_id:  attribution.id).first_or_create
       end
@@ -234,6 +234,10 @@ module Landable
 
       def referer_uri
         @referer_uri ||= URI(URI.encode(request.referer)) if request.referer
+      end
+
+      def referer_uri_path
+        referer_uri.path || ''
       end
 
       def external_referer?

--- a/spec/lib/landable/tracking_spec.rb
+++ b/spec/lib/landable/tracking_spec.rb
@@ -114,7 +114,17 @@ module Landable
     end
 
     context 'no referer' do
+      let(:referer) { double('referer', { path: nil}) }
       let(:visit) { double('visit', { referer: nil }) }
+
+      describe '#referer_uri_path' do
+        it 'should return empty string' do
+          tracker = Landable::Traffic::UserTracker.new controller
+          tracker.stub(:referer_uri) { referer }
+
+          tracker.send(:referer_uri_path).should == ''
+        end
+      end
 
       describe '#visit_referer_domain' do
         it 'should return nil' do


### PR DESCRIPTION
Seeing many instances where the path for the referer is, in fact, null, which has the side-effect of not allowing a visit to be created.  The referers model requires a path, this will default it to '' when none is present.