### PR TITLE
Rails 4.2 Support -> ActionController::Responder 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ See README.md before updating this file.
 
 ## Unreleased [#](https://github.com/enova/landable/compare/v1.12.1...master)
 * BugFix: Default referer.path to '' [#60]
+* BugFix: Include Responders Gem [#59]
 
 ## 1.12.3 [#](https://github.com/enova/landable/compare/v1.12.2...v1.12.3)
 * Feature: Add Traffic Object Helper [#50]

--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,5 @@ group :test do
   gem 'cucumber-rails', require: false
   gem 'test_after_commit'
 end
+
+gem 'responders', '~> 2.0'

--- a/features/liquid/tags.feature
+++ b/features/liquid/tags.feature
@@ -29,8 +29,8 @@ Feature: Liquid Tags
       | keywords | momoney,moproblems |
     Then the rendered content should be:
       """
-      <meta content="noindex,nofollow" name="robots" />
-      <meta content="momoney,moproblems" name="keywords" />
+      <meta name="robots" content="noindex,nofollow" />
+      <meta name="keywords" content="momoney,moproblems" />
       """
 
   Scenario: head_content
@@ -51,8 +51,8 @@ Feature: Liquid Tags
     Then the rendered content should be:
       """
       <title>Page Under Test</title>
-      <meta content="noindex,nofollow" name="robots" />
-      <meta content="momoney,moproblems" name="keywords" />
+      <meta name="robots" content="noindex,nofollow" />
+      <meta name="keywords" content="momoney,moproblems" />
       <head lang='en'><meta test='text'>
       """
 
@@ -73,8 +73,8 @@ Feature: Liquid Tags
       | keywords | momoney,moproblems |
     Then the rendered content should be:
       """
-      <div>Page body</div><meta content="noindex,nofollow" name="robots" />
-      <meta content="momoney,moproblems" name="keywords" />
+      <div>Page body</div><meta name="robots" content="noindex,nofollow" />
+      <meta name="keywords" content="momoney,moproblems" />
       """
 
   Scenario: img_tag

--- a/landable.gemspec
+++ b/landable.gemspec
@@ -37,6 +37,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency 'builder'
   gem.add_dependency 'lookup_by', '> 0.4.0'
   gem.add_dependency 'highline'
+  gem.add_dependency 'responders', '~> 2.0'
 
   gem.add_development_dependency 'pg'
   gem.add_development_dependency 'rspec-rails',        '~> 2.14.2'

--- a/spec/decorators/page_decorator_spec.rb
+++ b/spec/decorators/page_decorator_spec.rb
@@ -66,7 +66,7 @@ module Landable
       let(:page) { create :page, meta_tags: { content: 'robots', keyword: 'p2p' } }
 
       it 'lists the meta_tags seperated by a new line' do
-        page_decorator.meta_tags.should == %Q(<meta content="robots" name="content" />\n<meta content="p2p" name="keyword" />)
+        page_decorator.meta_tags.should == %Q(<meta name="content" content="robots" />\n<meta name="keyword" content="p2p" />)
         page_decorator.meta_tags.should be_html_safe
       end
 

--- a/spec/dummy/db/structure.sql
+++ b/spec/dummy/db/structure.sql
@@ -207,10 +207,10 @@ COMMENT ON TABLE assets IS 'List of all assets uploaded.
 CREATE TABLE audits (
     id integer NOT NULL,
     auditable_id uuid,
-    auditable_type character varying(255),
+    auditable_type character varying,
     notes text,
     approver text,
-    flags character varying(255)[] DEFAULT '{}'::character varying[],
+    flags character varying[] DEFAULT '{}'::character varying[],
     created_at timestamp without time zone,
     updated_at timestamp without time zone
 );
@@ -373,8 +373,8 @@ CREATE TABLE pages (
     abstract text,
     hero_asset_id uuid,
     deleted_at timestamp without time zone,
-    audit_flags character varying(255)[] DEFAULT '{}'::character varying[],
-    page_name character varying(255),
+    audit_flags character varying[] DEFAULT '{}'::character varying[],
+    page_name character varying,
     CONSTRAINT only_valid_paths CHECK ((path ~ '^/[a-zA-Z0-9/_.~-]*$'::text))
 );
 
@@ -427,7 +427,7 @@ CREATE TABLE templates (
     deleted_at timestamp without time zone,
     published_revision_id uuid,
     is_publishable boolean DEFAULT true,
-    audit_flags character varying(255)[] DEFAULT '{}'::character varying[]
+    audit_flags character varying[] DEFAULT '{}'::character varying[]
 );
 
 
@@ -1804,7 +1804,7 @@ SET search_path = public, pg_catalog;
 --
 
 CREATE TABLE schema_migrations (
-    version character varying(255) NOT NULL
+    version character varying NOT NULL
 );
 
 


### PR DESCRIPTION
http://edgeguides.rubyonrails.org/upgrading_ruby_on_rails.html#responders

Responders are now not included by default in Rails but have been extracted to a gem... 

https://github.com/rails/rails/pull/16526

We will need to include this gem to have Landable support Rails 4.2 
