### PR TITLE
Default AMQP to Empty Hash

### DIFF
--- a/lib/landable/configuration.rb
+++ b/lib/landable/configuration.rb
@@ -13,6 +13,10 @@ module Landable
     attr_writer :dnt_enabled, :amqp_event_mapping, :amqp_site_segment
     attr_writer :amqp_service_enabled, :amqp_messaging_service
 
+    def amqp_configuration
+      @amqp_configuration ||= {}
+    end
+
     def authenticators
       @authenticators || raise("No Landable authenticator configured.")
     end


### PR DESCRIPTION
make sure people dont have to initialize amqp_configuration in there landable.rb