### PR TITLE
Ava traffic logging fixes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,7 +46,7 @@ Metrics/AbcSize:
   Max: 391
 
 Metrics/ClassLength:
-  Max: 235
+  Max: 240
 
 Metrics/CyclomaticComplexity:
   Max: 12

--- a/app/models/landable/traffic/attribution.rb
+++ b/app/models/landable/traffic/attribution.rb
@@ -27,7 +27,11 @@ module Landable
         end
 
         def lookup(parameters)
-          where(transform(parameters)).first_or_create
+          begin
+            where(transform(parameters)).first_or_create
+          rescue ActiveRecord::RecordNotUnique
+            retry
+          end
         end
 
         def digest(parameters)

--- a/app/models/landable/traffic/attribution.rb
+++ b/app/models/landable/traffic/attribution.rb
@@ -27,11 +27,9 @@ module Landable
         end
 
         def lookup(parameters)
-          begin
-            where(transform(parameters)).first_or_create
-          rescue ActiveRecord::RecordNotUnique
-            retry
-          end
+          where(transform(parameters)).first_or_create
+        rescue ActiveRecord::RecordNotUnique
+          retry
         end
 
         def digest(parameters)

--- a/db/migrate/20131028145652_add_traffic_schema.rb
+++ b/db/migrate/20131028145652_add_traffic_schema.rb
@@ -94,7 +94,7 @@ class AddTrafficSchema < Landable::Migration
       CREATE TABLE attributions (
           attribution_id     SERIAL      PRIMARY KEY
 
-        , #{QUERY_PARAMS.map { |name| format('%s INTEGER REFERENCES %s', name.foreign_key, name.pluralize) }.join(',') }
+        , #{QUERY_PARAMS.map { |name| format('%s INTEGER REFERENCES %s', name.foreign_key, name.pluralize) }.join(',')}
 
         , created_at         TIMESTAMPTZ NOT NULL    DEFAULT NOW()
 

--- a/lib/landable/traffic/tracker.rb
+++ b/lib/landable/traffic/tracker.rb
@@ -299,11 +299,9 @@ module Landable
       end
 
       def visitor
-        begin
-          @visitor ||= Visitor.with_ip_address(ip_address).with_user_agent(user_agent).first_or_create
-        rescue ActiveRecord::RecordNotUnique
-          retry
-        end
+        @visitor ||= Visitor.with_ip_address(ip_address).with_user_agent(user_agent).first_or_create
+      rescue ActiveRecord::RecordNotUnique
+        retry
       end
 
       def visit

--- a/lib/landable/traffic/tracker.rb
+++ b/lib/landable/traffic/tracker.rb
@@ -172,10 +172,14 @@ module Landable
         attribution = Attribution.lookup params.slice(*ATTRIBUTION_KEYS)
         query       = params.except(*ATTRIBUTION_KEYS)
 
-        @referer = Referer.where(domain_id:       Domain[referer_uri.host],
-                                 path_id:         Path[referer_uri_path],
-                                 query_string_id: QueryString[query.to_query],
-                                 attribution_id:  attribution.id).first_or_create
+        begin
+          @referer = Referer.where(domain_id:       Domain[referer_uri.host],
+                                   path_id:         Path[referer_uri_path],
+                                   query_string_id: QueryString[query.to_query],
+                                   attribution_id:  attribution.id).first_or_create
+        rescue ActiveRecord::RecordNotUnique
+          retry
+        end
       end
 
       def ip_address
@@ -295,7 +299,11 @@ module Landable
       end
 
       def visitor
-        @visitor ||= Visitor.with_ip_address(ip_address).with_user_agent(user_agent).first_or_create
+        begin
+          @visitor ||= Visitor.with_ip_address(ip_address).with_user_agent(user_agent).first_or_create
+        rescue ActiveRecord::RecordNotUnique
+          retry
+        end
       end
 
       def visit

--- a/lib/landable/traffic/user_tracker.rb
+++ b/lib/landable/traffic/user_tracker.rb
@@ -55,12 +55,20 @@ module Landable
 
       def identify(identifier)
         visit = Visit.find(@visit_id)
-        owner = Owner.where(owner: identifier).first_or_create
+        begin
+          owner = Owner.where(owner: identifier).first_or_create
+        rescue ActiveRecord::RecordNotUnique
+          retry
+        end
 
         visit.owner = owner
         visit.save!
 
-        Ownership.where(cookie_id: @cookie_id, owner: owner).first_or_create
+        begin
+          Ownership.where(cookie_id: @cookie_id, owner: owner).first_or_create
+        rescue ActiveRecord::RecordNotUnique
+          retry
+        end
       end
     end
   end


### PR DESCRIPTION
Adding retry logic for non-atomic UPSERTs. This will fix a case where we are missing records in concurrent environments. 