### PR TITLE
added category_id to Template model

### DIFF
--- a/app/models/landable/template.rb
+++ b/app/models/landable/template.rb
@@ -13,6 +13,7 @@ module Landable
     before_save :slug_has_no_spaces
 
     belongs_to :published_revision,   class_name: 'Landable::TemplateRevision'
+    belongs_to :category,             class_name: 'Landable::Category'
     has_many :audits,               class_name: 'Landable::Audit', as: :auditable
     has_many :revisions,            class_name: 'Landable::TemplateRevision'
 

--- a/db/migrate/20150728195345_add_category_column_to_templates.rb
+++ b/db/migrate/20150728195345_add_category_column_to_templates.rb
@@ -1,0 +1,7 @@
+class AddCategoryColumnToTemplates < ActiveRecord::Migration
+  def change
+    schema_name = "#{Landable.configuration.database_schema_prefix}landable"
+    add_column "#{schema_name}.templates", :category_id, :uuid
+    execute "ALTER TABLE #{schema_name}.templates ADD FOREIGN KEY (category_id) REFERENCES #{schema_name}.categories(category_id)"
+  end
+end


### PR DESCRIPTION
Added category_id to the Template model, along with the necessary database migrations.

NOTE: ActiveRecord doesn't natively support foreign keys until Rails v.4.2.1 so we used plain SQL to add the foreign key.
