### PR TITLE
use strings or symbols for config keys

### DIFF
--- a/lib/landable/configuration.rb
+++ b/lib/landable/configuration.rb
@@ -1,7 +1,7 @@
 require 'figgy'
 
 module Landable
-  class Configuration < Hash
+  class Configuration < HashWithIndifferentAccess
     attr_accessor :api_url, :public_url, :amqp_configuration, :sitemap_host
     attr_writer :api_namespace, :public_namespace
     attr_writer :api_host, :public_host


### PR DESCRIPTION
dev: sortiz

simple update to have Landable::configuration inherit HashWithIndifferentAccess instead of Hash. This will allow any configuration options accessed from Landable::configuration to be so accessed with strings and symbols just the same, rather than one or the other.