### PR TITLE
Allow robots.txt to actually respond_to text/plain MIME

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ See README.md before updating this file.
 
 ## Unreleased [#](https://github.com/enova/landable/compare/v1.14.0...master)
 * Feature: Add CodeClimate metrics and test coverage for Travis
+* Feature: [Allow responding to text/plain MIME type](https://github.com/enova/landable/pull/90)
 
 ## 1.14.0 [#](https://github.com/enova/landable/compare/v1.13.2...v1.14.0)
 * Feature: Support permissions for an author

--- a/app/controllers/landable/public/pages_controller.rb
+++ b/app/controllers/landable/public/pages_controller.rb
@@ -3,7 +3,7 @@ require_dependency 'landable/application_controller'
 module Landable
   module Public
     class PagesController < ApplicationController
-      respond_to :html
+      respond_to :html, :text
 
       self.responder = Landable::PageRenderResponder
 

--- a/app/responders/landable/page_render_responder.rb
+++ b/app/responders/landable/page_render_responder.rb
@@ -9,5 +9,6 @@ module Landable
       else          fail page.error
       end
     end
+    alias to_text to_html
   end
 end


### PR DESCRIPTION
#### Issue
1000's of hits a day to /robots.txt are setting the Accept header to the `text/plain` MIME type (as they should be) instead of the `pages_controller`'s expected `text/html` response type.

#### Description
In general, we should simply allow a requester to specify that they want a page in plaintext instead of html.